### PR TITLE
added option to skip bad sectors in mkudffs

### DIFF
--- a/include/libudffs.h
+++ b/include/libudffs.h
@@ -145,6 +145,15 @@ struct udf_disc
 
 	struct udf_extent		*head;
 	struct udf_extent		*tail;
+	struct udf_badblock_frag	*badblocks_head;
+	struct udf_badblock_frag	**badblocks_tail;
+};
+
+struct udf_badblock_frag
+{
+	uint32_t			start;
+	uint32_t			blocks;
+	struct udf_badblock_frag	*next;
 };
 
 struct udf_extent
@@ -219,6 +228,7 @@ struct udf_desc *find_desc(struct udf_extent *, uint32_t);
 struct udf_desc *set_desc(struct udf_extent *, uint16_t, uint32_t, uint32_t, struct udf_data *);
 void append_data(struct udf_desc *, struct udf_data *);
 struct udf_data *alloc_data(void *, int);
+void add_badblocks(struct udf_disc *disc, uint32_t start, uint32_t blocks);
 
 /* unicode.c */
 extern size_t decode_utf8(const dchars *, char *, size_t, size_t);

--- a/libudffs/extent.c
+++ b/libudffs/extent.c
@@ -493,3 +493,17 @@ struct udf_data *alloc_data(void *buffer, int length)
 
 	return data;
 }
+
+/**
+ * @brief add a range of bad blocks to disc
+ */
+
+void add_badblocks(struct udf_disc *disc, uint32_t start, uint32_t blocks)
+{
+	struct udf_badblock_frag *frag = malloc(sizeof(*frag));
+	frag->start = start;
+	frag->blocks = blocks;
+	frag->next = NULL;
+	*disc->badblocks_tail = frag;
+	disc->badblocks_tail = &frag->next;
+}

--- a/mkudffs/mkudffs.c
+++ b/mkudffs/mkudffs.c
@@ -132,6 +132,8 @@ void udf_init_disc(struct udf_disc *disc)
 
 	disc->head = malloc(sizeof(struct udf_extent));
 	disc->tail = disc->head;
+	disc->badblocks_head = NULL;
+	disc->badblocks_tail = &disc->badblocks_head;
 
 	disc->head->space_type = USPACE;
 	disc->head->start = 0;
@@ -222,6 +224,7 @@ void split_space(struct udf_disc *disc)
 	uint32_t start, size, start2, size2;
 	struct sparablePartitionMap *spm;
 	struct udf_extent *ext;
+	struct udf_badblock_frag *bad_frag;
 	uint32_t accessType;
 	uint32_t i, j;
 
@@ -262,6 +265,17 @@ void split_space(struct udf_disc *disc)
 	// Final anchor point at sector End-Of-Volume/Session for sequentially writable media
 	if (!(disc->flags & FLAG_VAT))
 		set_extent(disc, ANCHOR, blocks-1, 1);
+
+	for (bad_frag = disc->badblocks_head; bad_frag; bad_frag = bad_frag->next)
+	{
+		uint32_t s = find_next_extent_size(disc, bad_frag->start, USPACE, bad_frag->blocks, 1);
+		if (s != bad_frag->start)
+		{
+			fprintf(stderr, "%s: Failed to reserve bad sectors starting from %ld length %ld\n", appname, (unsigned long)bad_frag->start, (unsigned long)bad_frag->blocks);
+			exit(1);
+		}
+		set_extent(disc, BAD, bad_frag->start, bad_frag->blocks);
+	}
 
 	// Calculate minimal size for Sparing Table needed for Sparing Space
 	if ((spm = find_type2_sparable_partition(disc, 0)) && disc->sizing[STABLE_SIZE].minSize == 0)

--- a/mkudffs/options.h
+++ b/mkudffs/options.h
@@ -65,5 +65,6 @@ void parse_args(int, char *[], struct udf_disc *, char **, int *, int *, int *);
 #define OPT_GID		0x2010
 #define OPT_MODE	0x2011
 #define OPT_BOOTAREA	0x2012
+#define OPT_BADBLOCKS	0x2013
 
 #endif /* _OPTIONS_H */


### PR DESCRIPTION
Hi Pali,

Would you mind take a look at this change? I've added a option to skip bad sectors in mkudffs. It allows disc to be formatted even if some sectors have worn out. It can also be used to reserve those sectors. Not sure if utilizing the "BAD" enum is the current approach.

Bo