### PR TITLE
Include <sys/sysmacros.h> to prevent build breakage with >=glibc-2.25

### DIFF
--- a/mkudffs/main.c
+++ b/mkudffs/main.c
@@ -43,6 +43,7 @@
 #include <sys/ioctl.h>
 #include <linux/fs.h>
 #include <linux/fd.h>
+#include <sys/sysmacros.h>
 
 #include "mkudffs.h"
 #include "defaults.h"


### PR DESCRIPTION
libtool: link: x86_64-pc-linux-gnu-gcc -march=native -mtune=native -O2
-pipe -Wl,-O1 -Wl,--hash-style=gnu -Wl,--sort-common -Wl,--as-needed -o
mkudffs main.o mkudffs.o defaults.o file.o options.o
../libudffs/.libs/libudffs.a
main.o: In function `is_whole_disk':
main.c:(.text+0x2ce): undefined reference to `major'
main.c:(.text+0x2dd): undefined reference to `minor'
main.o: In function `main':
main.c:(.text.startup+0x72f): undefined reference to `minor'
main.c:(.text.startup+0x741): undefined reference to `major'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:378: mkudffs] Error 1