### PR TITLE
cleaned-up macOS port (not fsck-related)

### DIFF
--- a/cdrwtool/cdrwtool.c
+++ b/cdrwtool/cdrwtool.c
@@ -32,9 +32,13 @@
 #include <limits.h>
 
 #include <sys/ioctl.h>
+#if defined(__linux__)
 #include <asm/param.h>
-
 #include <linux/cdrom.h>
+#else
+#include "bswap.h"
+#include "darwin/cdrom.h"
+#endif
 
 #include "cdrwtool.h"
 #include "../mkudffs/mkudffs.h"

--- a/cdrwtool/cdrwtool.h
+++ b/cdrwtool/cdrwtool.h
@@ -11,7 +11,11 @@
 #define _CDRWTOOL_H 1
 
 #include <inttypes.h>
+#if defined(__linux__)
 #include <linux/cdrom.h>
+#else
+#include "darwin/cdrom.h"
+#endif
 #include "../include/libudffs.h"
 
 /*

--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,12 @@ AC_SYS_LARGEFILE
 dnl Checks for library functions.
 AC_SUBST(LTLIBOBJS)
 
+dnl Enable Darwin extensions
+AC_CANONICAL_HOST
+AS_CASE([$host_os],
+       [darwin*], [CPPFLAGS="${CPPFLAGS} -D_DARWIN_C_SOURCE"])
+AM_CONDITIONAL(HAVE_DARWIN, test "${SYS}" = "darwin")
+
 AC_CONFIG_FILES(Makefile libudffs/Makefile mkudffs/Makefile cdrwtool/Makefile pktsetup/Makefile udffsck/Makefile udfinfo/Makefile udflabel/Makefile wrudf/Makefile doc/Makefile)
 
 AC_OUTPUT

--- a/include/bswap.h
+++ b/include/bswap.h
@@ -28,6 +28,9 @@
 #include <inttypes.h>
 #include <sys/types.h>
 
+#if defined(HAVE_MACHINE_ENDIAN_H)
+#include <machine/endian.h>
+#endif
 #ifdef HAVE_SYS_ISA_DEFS_H
 #define __LITTLE_ENDIAN 1234
 #define __BIG_ENDIAN 4321
@@ -41,6 +44,18 @@
 #define __BYTE_ORDER __BIG_ENDIAN
 #endif
 #endif
+
+/* macOS */
+#ifdef __APPLE__
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
+#define __BIG_ENDIAN BIG_ENDIAN
+#define __BYTE_ORDER BYTE_ORDER
+#if __BYTE_ORDER == BIG_ENDIAN
+#define __BIG_ENDIAN_BITFIELD
+#elif __BYTE_ORDER == LITTLE_ENDIAN
+#define __LITTLE_ENDIAN_BITFIELD
+#endif
+#endif /* __APPLE__ */
 
 #define constant_swab16(x) \
 	((uint16_t)((((uint16_t)(x) & 0x00FFU) << 8) | \

--- a/include/darwin/cdrom.h
+++ b/include/darwin/cdrom.h
@@ -1,0 +1,717 @@
+/*
+ * -- <darwin/cdrom.h>
+ * General header file for darwin CD-ROM drivers 
+ * Copyright (C) 1992         David Giller, rafetmad@oxy.edu
+ *               1994, 1995   Eberhard Moenkeberg, emoenke@gwdg.de
+ *               1996         David van Leeuwen, david@tm.tno.nl
+ *               1997, 1998   Erik Andersen, andersee@debian.org
+ *               1998-2000    Jens Axboe, axboe@suse.de
+ */
+ 
+#ifndef	_DARWIN_CDROM_H
+#define	_DARWIN_CDROM_H
+
+#include "darwin/types.h"
+
+/*******************************************************
+ * All Darwin CD-ROM application programs will use this 
+ * (and only this) include file.  It is my hope to provide Darwin with
+ * a uniform interface between software accessing CD-ROMs and the various 
+ * device drivers that actually talk to the drives.  There may still be
+ * 23 different kinds of strange CD-ROM drives, but at least there will 
+ * now be one, and only one, Darwin CD-ROM interface.
+ *
+ * Additionally, all Darwin application programs 
+ * should use the O_NONBLOCK option when opening a CD-ROM device 
+ * for subsequent ioctl commands.  This allows for neat system errors 
+ * like "No medium found" or "Wrong medium type" upon attempting to 
+ * mount or play an empty slot, mount an audio disc, or play a data disc.
+ * Generally, changing an application program to support O_NONBLOCK
+ * is as easy as the following:
+ *       -    drive = open("/dev/cdrom", O_RDONLY);
+ *       +    drive = open("/dev/cdrom", O_RDONLY | O_NONBLOCK);
+ * It is worth the small change.
+ *
+ *******************************************************/
+
+/* When a driver supports a certain function, but the cdrom drive we are 
+ * using doesn't, we will return the error EDRIVE_CANT_DO_THIS.  We will 
+ * borrow the "Operation not supported" error from the network folks to 
+ * accomplish this.  Maybe someday we will get a more targeted error code, 
+ * but this will do for now... */
+#define EDRIVE_CANT_DO_THIS  EOPNOTSUPP
+
+/*******************************************************
+ * The CD-ROM IOCTL commands  -- these should be supported by 
+ * all the various cdrom drivers.  For the CD-ROM ioctls, we 
+ * will commandeer byte 0x53, or 'S'.
+ *******************************************************/
+#define CDROMPAUSE		0x5301 /* Pause Audio Operation */ 
+#define CDROMRESUME		0x5302 /* Resume paused Audio Operation */
+#define CDROMPLAYMSF		0x5303 /* Play Audio MSF (struct cdrom_msf) */
+#define CDROMPLAYTRKIND		0x5304 /* Play Audio Track/index 
+                                           (struct cdrom_ti) */
+#define CDROMREADTOCHDR		0x5305 /* Read TOC header 
+                                           (struct cdrom_tochdr) */
+#define CDROMREADTOCENTRY	0x5306 /* Read TOC entry 
+                                           (struct cdrom_tocentry) */
+#define CDROMSTOP		0x5307 /* Stop the cdrom drive */
+#define CDROMSTART		0x5308 /* Start the cdrom drive */
+#define CDROMEJECT		0x5309 /* Ejects the cdrom media */
+#define CDROMVOLCTRL		0x530a /* Control output volume 
+                                           (struct cdrom_volctrl) */
+#define CDROMSUBCHNL		0x530b /* Read subchannel data 
+                                           (struct cdrom_subchnl) */
+#define CDROMREADMODE2		0x530c /* Read CDROM mode 2 data (2336 Bytes) 
+                                           (struct cdrom_read) */
+#define CDROMREADMODE1		0x530d /* Read CDROM mode 1 data (2048 Bytes)
+                                           (struct cdrom_read) */
+#define CDROMREADAUDIO		0x530e /* (struct cdrom_read_audio) */
+#define CDROMEJECT_SW		0x530f /* enable(1)/disable(0) auto-ejecting */
+#define CDROMMULTISESSION	0x5310 /* Obtain the start-of-last-session 
+                                           address of multi session disks 
+                                           (struct cdrom_multisession) */
+#define CDROM_GET_MCN		0x5311 /* Obtain the "Universal Product Code" 
+                                           if available (struct cdrom_mcn) */
+#define CDROM_GET_UPC		CDROM_GET_MCN  /* This one is depricated, 
+                                          but here anyway for compatability */
+#define CDROMRESET		0x5312 /* hard-reset the drive */
+#define CDROMVOLREAD		0x5313 /* Get the drive's volume setting 
+                                          (struct cdrom_volctrl) */
+#define CDROMREADRAW		0x5314	/* read data in raw mode (2352 Bytes)
+                                           (struct cdrom_read) */
+/* 
+ * These ioctls are used only used in aztcd.c and optcd.c
+ */
+#define CDROMREADCOOKED		0x5315	/* read data in cooked mode */
+#define CDROMSEEK		0x5316  /* seek msf address */
+  
+/*
+ * This ioctl is only used by the scsi-cd driver.  
+   It is for playing audio in logical block addressing mode.
+ */
+#define CDROMPLAYBLK		0x5317	/* (struct cdrom_blk) */
+
+/* 
+ * These ioctls are only used in optcd.c
+ */
+#define CDROMREADALL		0x5318	/* read all 2646 bytes */
+
+/* 
+ * These ioctls are (now) only in ide-cd.c for controlling 
+ * drive spindown time.  They should be implemented in the
+ * Uniform driver, via generic packet commands, GPCMD_MODE_SELECT_10,
+ * GPCMD_MODE_SENSE_10 and the GPMODE_POWER_PAGE...
+ *  -Erik
+ */
+#define CDROMGETSPINDOWN        0x531d
+#define CDROMSETSPINDOWN        0x531e
+
+/* 
+ * These ioctls are implemented through the uniform CD-ROM driver
+ * They _will_ be adopted by all CD-ROM drivers, when all the CD-ROM
+ * drivers are eventually ported to the uniform CD-ROM driver interface.
+ */
+#define CDROMCLOSETRAY		0x5319	/* pendant of CDROMEJECT */
+#define CDROM_SET_OPTIONS	0x5320  /* Set behavior options */
+#define CDROM_CLEAR_OPTIONS	0x5321  /* Clear behavior options */
+#define CDROM_SELECT_SPEED	0x5322  /* Set the CD-ROM speed */
+#define CDROM_SELECT_DISC	0x5323  /* Select disc (for juke-boxes) */
+#define CDROM_MEDIA_CHANGED	0x5325  /* Check is media changed  */
+#define CDROM_DRIVE_STATUS	0x5326  /* Get tray position, etc. */
+#define CDROM_DISC_STATUS	0x5327  /* Get disc type, etc. */
+#define CDROM_CHANGER_NSLOTS    0x5328  /* Get number of slots */
+#define CDROM_LOCKDOOR		0x5329  /* lock or unlock door */
+#define CDROM_DEBUG		0x5330	/* Turn debug messages on/off */
+#define CDROM_GET_CAPABILITY	0x5331	/* get capabilities */
+
+/* Note that scsi/scsi_ioctl.h also uses 0x5382 - 0x5386.
+ * Future CDROM ioctls should be kept below 0x537F
+ */
+
+/* This ioctl is only used by sbpcd at the moment */
+#define CDROMAUDIOBUFSIZ        0x5382	/* set the audio buffer size */
+					/* conflict with SCSI_IOCTL_GET_IDLUN */
+
+/* DVD-ROM Specific ioctls */
+#define DVD_READ_STRUCT		0x5390  /* Read structure */
+#define DVD_WRITE_STRUCT	0x5391  /* Write structure */
+#define DVD_AUTH		0x5392  /* Authentication */
+
+#define CDROM_SEND_PACKET	0x5393	/* send a packet to the drive */
+#define CDROM_NEXT_WRITABLE	0x5394	/* get next writable block */
+#define CDROM_LAST_WRITTEN	0x5395	/* get last block written on disc */
+
+/*******************************************************
+ * CDROM IOCTL structures
+ *******************************************************/
+
+/* Address in MSF format */
+struct cdrom_msf0		
+{
+	__u8	minute;
+	__u8	second;
+	__u8	frame;
+};
+
+/* Address in either MSF or logical format */
+union cdrom_addr		
+{
+	struct cdrom_msf0	msf;
+	int			lba;
+};
+
+/* This struct is used by the CDROMPLAYMSF ioctl */ 
+struct cdrom_msf 
+{
+	__u8	cdmsf_min0;	/* start minute */
+	__u8	cdmsf_sec0;	/* start second */
+	__u8	cdmsf_frame0;	/* start frame */
+	__u8	cdmsf_min1;	/* end minute */
+	__u8	cdmsf_sec1;	/* end second */
+	__u8	cdmsf_frame1;	/* end frame */
+};
+
+/* This struct is used by the CDROMPLAYTRKIND ioctl */
+struct cdrom_ti 
+{
+	__u8	cdti_trk0;	/* start track */
+	__u8	cdti_ind0;	/* start index */
+	__u8	cdti_trk1;	/* end track */
+	__u8	cdti_ind1;	/* end index */
+};
+
+/* This struct is used by the CDROMREADTOCHDR ioctl */
+struct cdrom_tochdr 	
+{
+	__u8	cdth_trk0;	/* start track */
+	__u8	cdth_trk1;	/* end track */
+};
+
+/* This struct is used by the CDROMVOLCTRL and CDROMVOLREAD ioctls */
+struct cdrom_volctrl
+{
+	__u8	channel0;
+	__u8	channel1;
+	__u8	channel2;
+	__u8	channel3;
+};
+
+/* This struct is used by the CDROMSUBCHNL ioctl */
+struct cdrom_subchnl 
+{
+	__u8	cdsc_format;
+	__u8	cdsc_audiostatus;
+	__u8	cdsc_adr:	4;
+	__u8	cdsc_ctrl:	4;
+	__u8	cdsc_trk;
+	__u8	cdsc_ind;
+	union cdrom_addr cdsc_absaddr;
+	union cdrom_addr cdsc_reladdr;
+};
+
+
+/* This struct is used by the CDROMREADTOCENTRY ioctl */
+struct cdrom_tocentry 
+{
+	__u8	cdte_track;
+	__u8	cdte_adr	:4;
+	__u8	cdte_ctrl	:4;
+	__u8	cdte_format;
+	union cdrom_addr cdte_addr;
+	__u8	cdte_datamode;
+};
+
+/* This struct is used by the CDROMREADMODE1, and CDROMREADMODE2 ioctls */
+struct cdrom_read      
+{
+	int	cdread_lba;
+	char 	*cdread_bufaddr;
+	int	cdread_buflen;
+};
+
+/* This struct is used by the CDROMREADAUDIO ioctl */
+struct cdrom_read_audio
+{
+	union cdrom_addr addr; /* frame address */
+	__u8 addr_format;    /* CDROM_LBA or CDROM_MSF */
+	int nframes;           /* number of 2352-byte-frames to read at once */
+	__u8 *buf;           /* frame buffer (size: nframes*2352 bytes) */
+};
+
+/* This struct is used with the CDROMMULTISESSION ioctl */
+struct cdrom_multisession
+{
+	union cdrom_addr addr; /* frame address: start-of-last-session 
+	                           (not the new "frame 16"!).  Only valid
+	                           if the "xa_flag" is true. */
+	__u8 xa_flag;        /* 1: "is XA disk" */
+	__u8 addr_format;    /* CDROM_LBA or CDROM_MSF */
+};
+
+/* This struct is used with the CDROM_GET_MCN ioctl.  
+ * Very few audio discs actually have Universal Product Code information, 
+ * which should just be the Medium Catalog Number on the box.  Also note 
+ * that the way the codeis written on CD is _not_ uniform across all discs!
+ */  
+struct cdrom_mcn 
+{
+  __u8 medium_catalog_number[14]; /* 13 ASCII digits, null-terminated */
+};
+
+/* This is used by the CDROMPLAYBLK ioctl */
+struct cdrom_blk 
+{
+	unsigned from;
+	unsigned short len;
+};
+
+#define CDROM_PACKET_SIZE	12
+
+#define CGC_DATA_UNKNOWN	0
+#define CGC_DATA_WRITE		1
+#define CGC_DATA_READ		2
+#define CGC_DATA_NONE		3
+
+/* for CDROM_PACKET_COMMAND ioctl */
+struct cdrom_generic_command
+{
+	unsigned char 		cmd[CDROM_PACKET_SIZE];
+	unsigned char 		*buffer;
+	unsigned int 		buflen;
+	int			stat;
+	struct request_sense	*sense;
+	unsigned char		data_direction;
+	int			quiet;
+	int			timeout;
+	void			*reserved[1];
+};
+
+
+/*
+ * A CD-ROM physical sector size is 2048, 2052, 2056, 2324, 2332, 2336, 
+ * 2340, or 2352 bytes long.  
+
+*         Sector types of the standard CD-ROM data formats:
+ *
+ * format   sector type               user data size (bytes)
+ * -----------------------------------------------------------------------------
+ *   1     (Red Book)    CD-DA          2352    (CD_FRAMESIZE_RAW)
+ *   2     (Yellow Book) Mode1 Form1    2048    (CD_FRAMESIZE)
+ *   3     (Yellow Book) Mode1 Form2    2336    (CD_FRAMESIZE_RAW0)
+ *   4     (Green Book)  Mode2 Form1    2048    (CD_FRAMESIZE)
+ *   5     (Green Book)  Mode2 Form2    2328    (2324+4 spare bytes)
+ *
+ *
+ *       The layout of the standard CD-ROM data formats:
+ * -----------------------------------------------------------------------------
+ * - audio (red):                  | audio_sample_bytes |
+ *                                 |        2352        |
+ *
+ * - data (yellow, mode1):         | sync - head - data - EDC - zero - ECC |
+ *                                 |  12  -   4  - 2048 -  4  -   8  - 276 |
+ *
+ * - data (yellow, mode2):         | sync - head - data |
+ *                                 |  12  -   4  - 2336 |
+ *
+ * - XA data (green, mode2 form1): | sync - head - sub - data - EDC - ECC |
+ *                                 |  12  -   4  -  8  - 2048 -  4  - 276 |
+ *
+ * - XA data (green, mode2 form2): | sync - head - sub - data - Spare |
+ *                                 |  12  -   4  -  8  - 2324 -  4    |
+ *
+ */
+
+/* Some generally useful CD-ROM information -- mostly based on the above */
+#define CD_MINS              74 /* max. minutes per CD, not really a limit */
+#define CD_SECS              60 /* seconds per minute */
+#define CD_FRAMES            75 /* frames per second */
+#define CD_SYNC_SIZE         12 /* 12 sync bytes per raw data frame */
+#define CD_MSF_OFFSET       150 /* MSF numbering offset of first frame */
+#define CD_CHUNK_SIZE        24 /* lowest-level "data bytes piece" */
+#define CD_NUM_OF_CHUNKS     98 /* chunks per frame */
+#define CD_FRAMESIZE_SUB     96 /* subchannel data "frame" size */
+#define CD_HEAD_SIZE          4 /* header (address) bytes per raw data frame */
+#define CD_SUBHEAD_SIZE       8 /* subheader bytes per raw XA data frame */
+#define CD_EDC_SIZE           4 /* bytes EDC per most raw data frame types */
+#define CD_ZERO_SIZE          8 /* bytes zero per yellow book mode 1 frame */
+#define CD_ECC_SIZE         276 /* bytes ECC per most raw data frame types */
+#define CD_FRAMESIZE       2048 /* bytes per frame, "cooked" mode */
+#define CD_FRAMESIZE_RAW   2352 /* bytes per frame, "raw" mode */
+#define CD_FRAMESIZE_RAWER 2646 /* The maximum possible returned bytes */ 
+/* most drives don't deliver everything: */
+#define CD_FRAMESIZE_RAW1 (CD_FRAMESIZE_RAW-CD_SYNC_SIZE) /*2340*/
+#define CD_FRAMESIZE_RAW0 (CD_FRAMESIZE_RAW-CD_SYNC_SIZE-CD_HEAD_SIZE) /*2336*/
+
+#define CD_XA_HEAD        (CD_HEAD_SIZE+CD_SUBHEAD_SIZE) /* "before data" part of raw XA frame */
+#define CD_XA_TAIL        (CD_EDC_SIZE+CD_ECC_SIZE) /* "after data" part of raw XA frame */
+#define CD_XA_SYNC_HEAD   (CD_SYNC_SIZE+CD_XA_HEAD) /* sync bytes + header of XA frame */
+
+/* CD-ROM address types (cdrom_tocentry.cdte_format) */
+#define	CDROM_LBA 0x01 /* "logical block": first frame is #0 */
+#define	CDROM_MSF 0x02 /* "minute-second-frame": binary, not bcd here! */
+
+/* bit to tell whether track is data or audio (cdrom_tocentry.cdte_ctrl) */
+#define	CDROM_DATA_TRACK	0x04
+
+/* The leadout track is always 0xAA, regardless of # of tracks on disc */
+#define	CDROM_LEADOUT		0xAA
+
+/* audio states (from SCSI-2, but seen with other drives, too) */
+#define	CDROM_AUDIO_INVALID	0x00	/* audio status not supported */
+#define	CDROM_AUDIO_PLAY	0x11	/* audio play operation in progress */
+#define	CDROM_AUDIO_PAUSED	0x12	/* audio play operation paused */
+#define	CDROM_AUDIO_COMPLETED	0x13	/* audio play successfully completed */
+#define	CDROM_AUDIO_ERROR	0x14	/* audio play stopped due to error */
+#define	CDROM_AUDIO_NO_STATUS	0x15	/* no current audio status to return */
+
+/* capability flags used with the uniform CD-ROM driver */ 
+#define CDC_CLOSE_TRAY		0x1     /* caddy systems _can't_ close */
+#define CDC_OPEN_TRAY		0x2     /* but _can_ eject.  */
+#define CDC_LOCK		0x4     /* disable manual eject */
+#define CDC_SELECT_SPEED 	0x8     /* programmable speed */
+#define CDC_SELECT_DISC		0x10    /* select disc from juke-box */
+#define CDC_MULTI_SESSION 	0x20    /* read sessions>1 */
+#define CDC_MCN			0x40    /* Medium Catalog Number */
+#define CDC_MEDIA_CHANGED 	0x80    /* media changed */
+#define CDC_PLAY_AUDIO		0x100   /* audio functions */
+#define CDC_RESET               0x200   /* hard reset device */
+#define CDC_IOCTLS              0x400   /* driver has non-standard ioctls */
+#define CDC_DRIVE_STATUS        0x800   /* driver implements drive status */
+#define CDC_GENERIC_PACKET	0x1000	/* driver implements generic packets */
+#define CDC_CD_R		0x2000	/* drive is a CD-R */
+#define CDC_CD_RW		0x4000	/* drive is a CD-RW */
+#define CDC_DVD			0x8000	/* drive is a DVD */
+#define CDC_DVD_R		0x10000	/* drive can write DVD-R */
+#define CDC_DVD_RAM		0x20000	/* drive can write DVD-RAM */
+
+/* drive status possibilities returned by CDROM_DRIVE_STATUS ioctl */
+#define CDS_NO_INFO		0	/* if not implemented */
+#define CDS_NO_DISC		1
+#define CDS_TRAY_OPEN		2
+#define CDS_DRIVE_NOT_READY	3
+#define CDS_DISC_OK		4
+
+/* return values for the CDROM_DISC_STATUS ioctl */
+/* can also return CDS_NO_[INFO|DISC], from above */
+#define CDS_AUDIO		100
+#define CDS_DATA_1		101
+#define CDS_DATA_2		102
+#define CDS_XA_2_1		103
+#define CDS_XA_2_2		104
+#define CDS_MIXED		105
+
+/* User-configurable behavior options for the uniform CD-ROM driver */
+#define CDO_AUTO_CLOSE		0x1     /* close tray on first open() */
+#define CDO_AUTO_EJECT		0x2     /* open tray on last release() */
+#define CDO_USE_FFLAGS		0x4     /* use O_NONBLOCK information on open */
+#define CDO_LOCK		0x8     /* lock tray on open files */
+#define CDO_CHECK_TYPE		0x10    /* check type on open for data */
+
+/* Special codes used when specifying changer slots. */
+#define CDSL_NONE       	((int) (~0U>>1)-1)
+#define CDSL_CURRENT    	((int) (~0U>>1))
+
+/* For partition based multisession access. IDE can handle 64 partitions
+ * per drive - SCSI CD-ROM's use minors to differentiate between the
+ * various drives, so we can't do multisessions the same way there.
+ * Use the -o session=x option to mount on them.
+ */
+#define CD_PART_MAX		64
+#define CD_PART_MASK		(CD_PART_MAX - 1)
+
+/*********************************************************************
+ * Generic Packet commands, MMC commands, and such
+ *********************************************************************/
+
+ /* The generic packet command opcodes for CD/DVD Logical Units,
+ * From Table 57 of the SFF8090 Ver. 3 (Mt. Fuji) draft standard. */
+#define GPCMD_BLANK			    0xa1
+#define GPCMD_CLOSE_TRACK		    0x5b
+#define GPCMD_FLUSH_CACHE		    0x35
+#define GPCMD_FORMAT_UNIT		    0x04
+#define GPCMD_GET_CONFIGURATION		    0x46
+#define GPCMD_GET_EVENT_STATUS_NOTIFICATION 0x4a
+#define GPCMD_GET_PERFORMANCE		    0xac
+#define GPCMD_INQUIRY			    0x12
+#define GPCMD_LOAD_UNLOAD		    0xa6
+#define GPCMD_MECHANISM_STATUS		    0xbd
+#define GPCMD_MODE_SELECT_10		    0x55
+#define GPCMD_MODE_SENSE_10		    0x5a
+#define GPCMD_PAUSE_RESUME		    0x4b
+#define GPCMD_PLAY_AUDIO_10		    0x45
+#define GPCMD_PLAY_AUDIO_MSF		    0x47
+#define GPCMD_PLAY_AUDIO_TI		    0x48
+#define GPCMD_PLAY_CD			    0xbc
+#define GPCMD_PREVENT_ALLOW_MEDIUM_REMOVAL  0x1e
+#define GPCMD_READ_10			    0x28
+#define GPCMD_READ_12			    0xa8
+#define GPCMD_READ_CDVD_CAPACITY	    0x25
+#define GPCMD_READ_CD			    0xbe
+#define GPCMD_READ_CD_MSF		    0xb9
+#define GPCMD_READ_DISC_INFO		    0x51
+#define GPCMD_READ_DVD_STRUCTURE	    0xad
+#define GPCMD_READ_FORMAT_CAPACITIES	    0x23
+#define GPCMD_READ_HEADER		    0x44
+#define GPCMD_READ_TRACK_RZONE_INFO	    0x52
+#define GPCMD_READ_SUBCHANNEL		    0x42
+#define GPCMD_READ_TOC_PMA_ATIP		    0x43
+#define GPCMD_REPAIR_RZONE_TRACK	    0x58
+#define GPCMD_REPORT_KEY		    0xa4
+#define GPCMD_REQUEST_SENSE		    0x03
+#define GPCMD_RESERVE_RZONE_TRACK	    0x53
+#define GPCMD_SCAN			    0xba
+#define GPCMD_SEEK			    0x2b
+#define GPCMD_SEND_DVD_STRUCTURE	    0xad
+#define GPCMD_SEND_EVENT		    0xa2
+#define GPCMD_SEND_KEY			    0xa3
+#define GPCMD_SEND_OPC			    0x54
+#define GPCMD_SET_READ_AHEAD		    0xa7
+#define GPCMD_SET_STREAMING		    0xb6
+#define GPCMD_START_STOP_UNIT		    0x1b
+#define GPCMD_STOP_PLAY_SCAN		    0x4e
+#define GPCMD_TEST_UNIT_READY		    0x00
+#define GPCMD_VERIFY_10			    0x2f
+#define GPCMD_WRITE_10			    0x2a
+#define GPCMD_WRITE_AND_VERIFY_10	    0x2e
+/* This is listed as optional in ATAPI 2.6, but is (curiously) 
+ * missing from Mt. Fuji, Table 57.  It _is_ mentioned in Mt. Fuji
+ * Table 377 as an MMC command for SCSi devices though...  Most ATAPI
+ * drives support it. */
+#define GPCMD_SET_SPEED			    0xbb
+/* This seems to be a SCSI specific CD-ROM opcode 
+ * to play data at track/index */
+#define GPCMD_PLAYAUDIO_TI		    0x48
+/*
+ * From MS Media Status Notification Support Specification. For
+ * older drives only.
+ */
+#define GPCMD_GET_MEDIA_STATUS		    0xda
+
+/* Mode page codes for mode sense/set */
+#define GPMODE_R_W_ERROR_PAGE		0x01
+#define GPMODE_WRITE_PARMS_PAGE		0x05
+#define GPMODE_AUDIO_CTL_PAGE		0x0e
+#define GPMODE_POWER_PAGE		0x1a
+#define GPMODE_FAULT_FAIL_PAGE		0x1c
+#define GPMODE_TO_PROTECT_PAGE		0x1d
+#define GPMODE_CAPABILITIES_PAGE	0x2a
+#define GPMODE_ALL_PAGES		0x3f
+/* Not in Mt. Fuji, but in ATAPI 2.6 -- depricated now in favor
+ * of MODE_SENSE_POWER_PAGE */
+#define GPMODE_CDROM_PAGE		0x0d
+
+
+
+/* DVD struct types */
+#define DVD_STRUCT_PHYSICAL	0x00
+#define DVD_STRUCT_COPYRIGHT	0x01
+#define DVD_STRUCT_DISCKEY	0x02
+#define DVD_STRUCT_BCA		0x03
+#define DVD_STRUCT_MANUFACT	0x04
+
+struct dvd_layer {
+	__u8 book_version	: 4;
+	__u8 book_type		: 4;
+	__u8 min_rate		: 4;
+	__u8 disc_size		: 4;
+	__u8 layer_type		: 4;
+	__u8 track_path		: 1;
+	__u8 nlayers		: 2;
+	__u8 track_density	: 4;
+	__u8 linear_density	: 4;
+	__u8 bca		: 1;
+	__u32 start_sector;
+	__u32 end_sector;
+	__u32 end_sector_l0;
+};
+
+#define DVD_LAYERS	4
+
+struct dvd_physical {
+	__u8 type;
+	__u8 layer_num;
+	struct dvd_layer layer[DVD_LAYERS];
+};
+
+struct dvd_copyright {
+	__u8 type;
+
+	__u8 layer_num;
+	__u8 cpst;
+	__u8 rmi;
+};
+
+struct dvd_disckey {
+	__u8 type;
+
+	unsigned agid		: 2;
+	__u8 value[2048];
+};
+
+struct dvd_bca {
+	__u8 type;
+
+	int len;
+	__u8 value[188];
+};
+
+struct dvd_manufact {
+	__u8 type;
+
+	__u8 layer_num;
+	int len;
+	__u8 value[2048];
+};
+
+typedef union {
+	__u8 type;
+
+	struct dvd_physical	physical;
+	struct dvd_copyright	copyright;
+	struct dvd_disckey	disckey;
+	struct dvd_bca		bca;
+	struct dvd_manufact	manufact;
+} dvd_struct;
+
+#define CDROM_MAX_CDROMS	256
+
+/*
+ * DVD authentication ioctl
+ */
+
+/* Authentication states */
+#define DVD_LU_SEND_AGID	0
+#define DVD_HOST_SEND_CHALLENGE	1
+#define DVD_LU_SEND_KEY1	2
+#define DVD_LU_SEND_CHALLENGE	3
+#define DVD_HOST_SEND_KEY2	4
+
+/* Termination states */
+#define DVD_AUTH_ESTABLISHED	5
+#define DVD_AUTH_FAILURE	6
+
+/* Other functions */
+#define DVD_LU_SEND_TITLE_KEY	7
+#define DVD_LU_SEND_ASF		8
+#define DVD_INVALIDATE_AGID	9
+#define DVD_LU_SEND_RPC_STATE	10
+#define DVD_HOST_SEND_RPC_STATE	11
+
+/* State data */
+typedef __u8 dvd_key[5];		/* 40-bit value, MSB is first elem. */
+typedef __u8 dvd_challenge[10];	/* 80-bit value, MSB is first elem. */
+
+struct dvd_lu_send_agid {
+	__u8 type;
+	unsigned agid		: 2;
+};
+
+struct dvd_host_send_challenge {
+	__u8 type;
+	unsigned agid		: 2;
+
+	dvd_challenge chal;
+};
+
+struct dvd_send_key {
+	__u8 type;
+	unsigned agid		: 2;
+
+	dvd_key key;
+};
+
+struct dvd_lu_send_challenge {
+	__u8 type;
+	unsigned agid		: 2;
+
+	dvd_challenge chal;
+};
+
+#define DVD_CPM_NO_COPYRIGHT	0
+#define DVD_CPM_COPYRIGHTED	1
+
+#define DVD_CP_SEC_NONE		0
+#define DVD_CP_SEC_EXIST	1
+
+#define DVD_CGMS_UNRESTRICTED	0
+#define DVD_CGMS_SINGLE		2
+#define DVD_CGMS_RESTRICTED	3
+
+struct dvd_lu_send_title_key {
+	__u8 type;
+	unsigned agid		: 2;
+
+	dvd_key title_key;
+	int lba;
+	unsigned cpm		: 1;
+	unsigned cp_sec		: 1;
+	unsigned cgms		: 2;
+};
+
+struct dvd_lu_send_asf {
+	__u8 type;
+	unsigned agid		: 2;
+
+	unsigned asf		: 1;
+};
+
+struct dvd_host_send_rpcstate {
+	__u8 type;
+	__u8 pdrc;
+};
+
+struct dvd_lu_send_rpcstate {
+	__u8 type		: 2;
+	__u8 vra		: 3;
+	__u8 ucca		: 3;
+	__u8 region_mask;
+	__u8 rpc_scheme;
+};
+
+typedef union {
+	__u8 type;
+
+	struct dvd_lu_send_agid		lsa;
+	struct dvd_host_send_challenge	hsc;
+	struct dvd_send_key		lsk;
+	struct dvd_lu_send_challenge	lsc;
+	struct dvd_send_key		hsk;
+	struct dvd_lu_send_title_key	lstk;
+	struct dvd_lu_send_asf		lsasf;
+	struct dvd_host_send_rpcstate	hrpcs;
+	struct dvd_lu_send_rpcstate	lrpcs;
+} dvd_authinfo;
+
+struct request_sense {
+#if defined(__BIG_ENDIAN_BITFIELD)
+	__u8 valid		: 1;
+	__u8 error_code		: 7;
+#elif defined(__LITTLE_ENDIAN_BITFIELD)
+	__u8 error_code		: 7;
+	__u8 valid		: 1;
+#endif
+	__u8 segment_number;
+#if defined(__BIG_ENDIAN_BITFIELD)
+	__u8 reserved1		: 2;
+	__u8 ili		: 1;
+	__u8 reserved2		: 1;
+	__u8 sense_key		: 4;
+#elif defined(__LITTLE_ENDIAN_BITFIELD)
+	__u8 sense_key		: 4;
+	__u8 reserved2		: 1;
+	__u8 ili		: 1;
+	__u8 reserved1		: 2;
+#endif
+	__u8 information[4];
+	__u8 add_sense_len;
+	__u8 command_info[4];
+	__u8 asc;
+	__u8 ascq;
+	__u8 fruc;
+	__u8 sks[3];
+	__u8 asb[46];
+};
+
+
+#endif  /* _DARWIN_CDROM_H */

--- a/include/darwin/hdreg.h
+++ b/include/darwin/hdreg.h
@@ -1,0 +1,337 @@
+#ifndef _DARWIN_HDREG_H
+#define _DARWIN_HDREG_H
+
+/*
+ * This file contains some defines for the AT-hd-controller.
+ * Various sources.  
+ */
+
+#define HD_IRQ 14		/* the standard disk interrupt */
+
+/* ide.c has its own port definitions in "ide.h" */
+
+/* Hd controller regs. Ref: IBM AT Bios-listing */
+#define HD_DATA		0x1f0	/* _CTL when writing */
+#define HD_ERROR	0x1f1	/* see err-bits */
+#define HD_NSECTOR	0x1f2	/* nr of sectors to read/write */
+#define HD_SECTOR	0x1f3	/* starting sector */
+#define HD_LCYL		0x1f4	/* starting cylinder */
+#define HD_HCYL		0x1f5	/* high byte of starting cyl */
+#define HD_CURRENT	0x1f6	/* 101dhhhh , d=drive, hhhh=head */
+#define HD_STATUS	0x1f7	/* see status-bits */
+#define HD_FEATURE HD_ERROR	/* same io address, read=error, write=feature */
+#define HD_PRECOMP HD_FEATURE	/* obsolete use of this port - predates IDE */
+#define HD_COMMAND HD_STATUS	/* same io address, read=status, write=cmd */
+
+#define HD_CMD		0x3f6	/* used for resets */
+#define HD_ALTSTATUS	0x3f6	/* same as HD_STATUS but doesn't clear irq */
+
+/* remainder is shared between hd.c, ide.c, ide-cd.c, and the hdparm utility */
+
+/* Bits of HD_STATUS */
+#define ERR_STAT	0x01
+#define INDEX_STAT	0x02
+#define ECC_STAT	0x04	/* Corrected error */
+#define DRQ_STAT	0x08
+#define SEEK_STAT	0x10
+#define WRERR_STAT	0x20
+#define READY_STAT	0x40
+#define BUSY_STAT	0x80
+
+/* Values for HD_COMMAND */
+#define WIN_RESTORE		0x10
+#define WIN_READ		0x20
+#define WIN_WRITE		0x30
+#define WIN_WRITE_VERIFY	0x3C
+#define WIN_VERIFY		0x40
+#define WIN_FORMAT		0x50
+#define WIN_INIT		0x60
+#define WIN_SEEK		0x70
+#define WIN_DIAGNOSE		0x90
+#define WIN_SPECIFY		0x91	/* set drive geometry translation */
+#define WIN_IDLEIMMEDIATE	0xE1	/* force drive to become "ready" */
+#define WIN_SETIDLE1		0xE3
+#define WIN_SETIDLE2		0x97
+
+#define WIN_STANDBYNOW1		0xE0
+#define WIN_STANDBYNOW2		0x94
+#define WIN_SLEEPNOW1		0xE6
+#define WIN_SLEEPNOW2		0x99
+#define WIN_CHECKPOWERMODE1	0xE5
+#define WIN_CHECKPOWERMODE2	0x98
+
+#define WIN_DOORLOCK		0xDE	/* lock door on removable drives */
+#define WIN_DOORUNLOCK		0xDF	/* unlock door on removable drives */
+
+#define WIN_MULTREAD		0xC4	/* read sectors using multiple mode */
+#define WIN_MULTWRITE		0xC5	/* write sectors using multiple mode */
+#define WIN_SETMULT		0xC6	/* enable/disable multiple mode */
+#define WIN_IDENTIFY		0xEC	/* ask drive to identify itself	*/
+#define WIN_IDENTIFY_DMA	0xEE	/* same as WIN_IDENTIFY, but DMA */
+#define WIN_SETFEATURES		0xEF	/* set special drive features */
+#define WIN_READDMA		0xC8	/* read sectors using DMA transfers */
+#define WIN_WRITEDMA		0xCA	/* write sectors using DMA transfers */
+
+#define WIN_QUEUED_SERVICE	0xA2	/* */
+#define WIN_READDMA_QUEUED	0xC7	/* read sectors using Queued DMA transfers */
+#define WIN_WRITEDMA_QUEUED	0xCC	/* write sectors using Queued DMA transfers */
+
+#define WIN_READ_BUFFER		0xE4	/* force read only 1 sector */
+#define WIN_WRITE_BUFFER	0xE8	/* force write only 1 sector */
+
+#define WIN_SMART		0xB0	/* self-monitoring and reporting */
+
+/* Additional drive command codes used by ATAPI devices. */
+#define WIN_PIDENTIFY		0xA1	/* identify ATAPI device	*/
+#define WIN_SRST		0x08	/* ATAPI soft reset command */
+#define WIN_PACKETCMD		0xA0	/* Send a packet command. */
+
+#define DISABLE_SEAGATE		0xFB
+#define EXABYTE_ENABLE_NEST	0xF0
+
+/* WIN_SMART sub-commands */
+
+#define SMART_READ_VALUES	0xd0
+#define SMART_READ_THRESHOLDS	0xd1
+#define SMART_AUTOSAVE		0xd2
+#define SMART_SAVE		0xd3
+#define SMART_IMMEDIATE_OFFLINE	0xd4
+#define SMART_READ_LOG_SECTOR	0xd5
+#define SMART_WRITE_LOG_SECTOR	0xd6
+#define SMART_WRITE_THRESHOLDS	0xd7
+#define SMART_ENABLE		0xd8
+#define SMART_DISABLE		0xd9
+#define SMART_STATUS		0xda
+#define SMART_AUTO_OFFLINE	0xdb
+
+/* WIN_SETFEATURES sub-commands */
+
+#define SETFEATURES_EN_WCACHE	0x02	/* Enable write cache */
+#define SETFEATURES_XFER	0x03	/* Set transfer mode */
+#	define XFER_UDMA_7	0x47	/* 0100|0111 */
+#	define XFER_UDMA_6	0x46	/* 0100|0110 */
+#	define XFER_UDMA_5	0x45	/* 0100|0101 */
+#	define XFER_UDMA_4	0x44	/* 0100|0100 */
+#	define XFER_UDMA_3	0x43	/* 0100|0011 */
+#	define XFER_UDMA_2	0x42	/* 0100|0010 */
+#	define XFER_UDMA_1	0x41	/* 0100|0001 */
+#	define XFER_UDMA_0	0x40	/* 0100|0000 */
+#	define XFER_MW_DMA_2	0x22	/* 0010|0010 */
+#	define XFER_MW_DMA_1	0x21	/* 0010|0001 */
+#	define XFER_MW_DMA_0	0x20	/* 0010|0000 */
+#	define XFER_SW_DMA_2	0x12	/* 0001|0010 */
+#	define XFER_SW_DMA_1	0x11	/* 0001|0001 */
+#	define XFER_SW_DMA_0	0x10	/* 0001|0000 */
+#	define XFER_PIO_4	0x0C	/* 0000|1100 */
+#	define XFER_PIO_3	0x0B	/* 0000|1011 */
+#	define XFER_PIO_2	0x0A	/* 0000|1010 */
+#	define XFER_PIO_1	0x09	/* 0000|1001 */
+#	define XFER_PIO_0	0x08	/* 0000|1000 */
+#	define XFER_PIO_SLOW	0x00	/* 0000|0000 */
+#define SETFEATURES_DIS_DEFECT	0x04	/* Disable Defect Management */
+#define SETFEATURES_EN_APM	0x05	/* Enable advanced power management */
+#define SETFEATURES_DIS_MSN	0x31	/* Disable Media Status Notification */
+#define SETFEATURES_DIS_RLA	0x55	/* Disable read look-ahead feature */
+#define SETFEATURES_EN_RI	0x5D	/* Enable release interrupt */
+#define SETFEATURES_EN_SI	0x5E	/* Enable SERVICE interrupt */
+#define SETFEATURES_DIS_RPOD	0x66	/* Disable reverting to power on defaults */
+#define SETFEATURES_DIS_WCACHE	0x82	/* Disable write cache */
+#define SETFEATURES_EN_DEFECT	0x84	/* Enable Defect Management */
+#define SETFEATURES_DIS_APM	0x85	/* Disable advanced power management */
+#define SETFEATURES_EN_MSN	0x95	/* Enable Media Status Notification */
+#define SETFEATURES_EN_RLA	0xAA	/* Enable read look-ahead feature */
+#define SETFEATURES_PREFETCH	0xAB	/* Sets drive prefetch value */
+#define SETFEATURES_EN_RPOD	0xCC	/* Enable reverting to power on defaults */
+#define SETFEATURES_DIS_RI	0xDD	/* Disable release interrupt */
+#define SETFEATURES_DIS_SI	0xDE	/* Disable SERVICE interrupt */
+
+/* WIN_SECURITY sub-commands */
+
+#define SECURITY_SET_PASSWORD		0xBA	/* 0xF1 */
+#define SECURITY_UNLOCK			0xBB	/* 0xF2 */
+#define SECURITY_ERASE_PREPARE		0xBC	/* 0xF3 */
+#define SECURITY_ERASE_UNIT		0xBD	/* 0xF4 */
+#define SECURITY_FREEZE_LOCK		0xBE	/* 0xF5 */
+#define SECURITY_DISABLE_PASSWORD	0xBF	/* 0xF6 */
+
+/* Bits for HD_ERROR */
+#define MARK_ERR	0x01	/* Bad address mark */
+#define TRK0_ERR	0x02	/* couldn't find track 0 */
+#define ABRT_ERR	0x04	/* Command aborted */
+#define MCR_ERR		0x08	/* media change request */
+#define ID_ERR		0x10	/* ID field not found */
+#define MC_ERR		0x20	/* media changed */
+#define ECC_ERR		0x40	/* Uncorrectable ECC error */
+#define	BBD_ERR		0x80	/* pre-EIDE meaning:  block marked bad */
+#define	ICRC_ERR	0x80	/* new meaning:  CRC error during transfer */
+
+struct hd_geometry {
+      unsigned char heads;
+      unsigned char sectors;
+      unsigned short cylinders;
+      unsigned long start;
+};
+
+/* hd/ide ctl's that pass (arg) ptrs to user space are numbered 0x030n/0x031n */
+#define HDIO_GETGEO		0x0301	/* get device geometry */
+#define HDIO_GET_UNMASKINTR	0x0302	/* get current unmask setting */
+#define HDIO_GET_MULTCOUNT	0x0304	/* get current IDE blockmode setting */
+#define HDIO_GET_QDMA		0x0305	/* get use-qdma flag */
+#define HDIO_OBSOLETE_IDENTITY	0x0307	/* OBSOLETE, DO NOT USE: returns 142 bytes */
+#define HDIO_GET_KEEPSETTINGS	0x0308	/* get keep-settings-on-reset flag */
+#define HDIO_GET_32BIT		0x0309	/* get current io_32bit setting */
+#define HDIO_GET_NOWERR		0x030a	/* get ignore-write-error flag */
+#define HDIO_GET_DMA		0x030b	/* get use-dma flag */
+#define HDIO_GET_NICE		0x030c	/* get nice flags */
+#define HDIO_GET_IDENTITY	0x030d	/* get IDE identification info */
+#define HDIO_GET_WCACHE		0x030e	/* get write cache mode on|off */
+#define HDIO_GET_ACOUSTIC	0x030f	/* get acoustic value */
+
+#define HDIO_GET_BUSSTATE	0x031a	/* get the bus state of the hwif */
+#define HDIO_TRISTATE_HWIF	0x031b	/* OBSOLETE - use SET_BUSSTATE */
+#define HDIO_DRIVE_RESET	0x031c	/* execute a device reset */
+#define HDIO_DRIVE_TASKFILE	0x031d	/* execute raw taskfile */
+#define HDIO_DRIVE_TASK		0x031e	/* execute task and special drive command */
+#define HDIO_DRIVE_CMD		0x031f	/* execute a special drive command */
+
+#define HDIO_DRIVE_CMD_AEB	HDIO_DRIVE_TASK
+
+/* hd/ide ctl's that pass (arg) non-ptr values are numbered 0x032n/0x033n */
+#define HDIO_SET_MULTCOUNT	0x0321	/* change IDE blockmode */
+#define HDIO_SET_UNMASKINTR	0x0322	/* permit other irqs during I/O */
+#define HDIO_SET_KEEPSETTINGS	0x0323	/* keep ioctl settings on reset */
+#define HDIO_SET_32BIT		0x0324	/* change io_32bit flags */
+#define HDIO_SET_NOWERR		0x0325	/* change ignore-write-error flag */
+#define HDIO_SET_DMA		0x0326	/* change use-dma flag */
+#define HDIO_SET_PIO_MODE	0x0327	/* reconfig interface to new speed */
+#define HDIO_SCAN_HWIF		0x0328	/* register and (re)scan interface */
+#define HDIO_SET_NICE		0x0329	/* set nice flags */
+#define HDIO_UNREGISTER_HWIF	0x032a  /* unregister interface */
+#define HDIO_SET_WCACHE		0x032b	/* change write cache enable-disable */
+#define HDIO_SET_ACOUSTIC	0x032c	/* change acoustic behavior */
+#define HDIO_SET_BUSSTATE	0x032d	/* set the bus state of the hwif */
+#define HDIO_SET_QDMA		0x032e	/* change use-qdma flag */
+
+/* bus states */
+enum {
+	BUSSTATE_OFF = 0,
+	BUSSTATE_ON,
+	BUSSTATE_TRISTATE
+};
+
+/* BIG GEOMETRY */
+struct hd_big_geometry {
+	unsigned char heads;
+	unsigned char sectors;
+	unsigned int cylinders;
+	unsigned long start;
+};
+
+/* hd/ide ctl's that pass (arg) ptrs to user space are numbered 0x033n/0x033n */
+#define HDIO_GETGEO_BIG		0x0330	/* */
+#define HDIO_GETGEO_BIG_RAW	0x0331	/* */
+
+#define __NEW_HD_DRIVE_ID
+/* structure returned by HDIO_GET_IDENTITY, as per ANSI ATA2 rev.2f spec */
+struct hd_driveid {
+	unsigned short	config;		/* lots of obsolete bit flags */
+	unsigned short	cyls;		/* "physical" cyls */
+	unsigned short	reserved2;	/* reserved (word 2) */
+	unsigned short	heads;		/* "physical" heads */
+	unsigned short	track_bytes;	/* unformatted bytes per track */
+	unsigned short	sector_bytes;	/* unformatted bytes per sector */
+	unsigned short	sectors;	/* "physical" sectors per track */
+	unsigned short	vendor0;	/* vendor unique */
+	unsigned short	vendor1;	/* vendor unique */
+	unsigned short	vendor2;	/* vendor unique */
+	unsigned char	serial_no[20];	/* 0 = not_specified */
+	unsigned short	buf_type;
+	unsigned short	buf_size;	/* 512 byte increments; 0 = not_specified */
+	unsigned short	ecc_bytes;	/* for r/w long cmds; 0 = not_specified */
+	unsigned char	fw_rev[8];	/* 0 = not_specified */
+	unsigned char	model[40];	/* 0 = not_specified */
+	unsigned char	max_multsect;	/* 0=not_implemented */
+	unsigned char	vendor3;	/* vendor unique */
+	unsigned short	dword_io;	/* 0=not_implemented; 1=implemented */
+	unsigned char	vendor4;	/* vendor unique */
+	unsigned char	capability;	/* bits 0:DMA 1:LBA 2:IORDYsw 3:IORDYsup*/
+	unsigned short	reserved50;	/* reserved (word 50) */
+	unsigned char	vendor5;	/* vendor unique */
+	unsigned char	tPIO;		/* 0=slow, 1=medium, 2=fast */
+	unsigned char	vendor6;	/* vendor unique */
+	unsigned char	tDMA;		/* 0=slow, 1=medium, 2=fast */
+	unsigned short	field_valid;	/* bits 0:cur_ok 1:eide_ok */
+	unsigned short	cur_cyls;	/* logical cylinders */
+	unsigned short	cur_heads;	/* logical heads */
+	unsigned short	cur_sectors;	/* logical sectors per track */
+	unsigned short	cur_capacity0;	/* logical total sectors on drive */
+	unsigned short	cur_capacity1;	/*  (2 words, misaligned int)     */
+	unsigned char	multsect;	/* current multiple sector count */
+	unsigned char	multsect_valid;	/* when (bit0==1) multsect is ok */
+	unsigned int	lba_capacity;	/* total number of sectors */
+	unsigned short	dma_1word;	/* single-word dma info */
+	unsigned short	dma_mword;	/* multiple-word dma info */
+	unsigned short  eide_pio_modes; /* bits 0:mode3 1:mode4 */
+	unsigned short  eide_dma_min;	/* min mword dma cycle time (ns) */
+	unsigned short  eide_dma_time;	/* recommended mword dma cycle time (ns) */
+	unsigned short  eide_pio;       /* min cycle time (ns), no IORDY  */
+	unsigned short  eide_pio_iordy; /* min cycle time (ns), with IORDY */
+	unsigned short	words69_70[2];	/* reserved words 69-70 */
+	/* HDIO_GET_IDENTITY currently returns only words 0 through 70 */
+	unsigned short	words71_74[4];	/* reserved words 71-74 */
+	unsigned short  queue_depth;	/*  */
+	unsigned short  words76_79[4];	/* reserved words 76-79 */
+	unsigned short  major_rev_num;	/*  */
+	unsigned short  minor_rev_num;	/*  */
+	unsigned short  command_set_1;	/* bits 0:Smart 1:Security 2:Removable 3:PM */
+	unsigned short  command_set_2;	/* bits 14:Smart Enabled 13:0 zero */
+	unsigned short  cfsse;		/* command set-feature supported extensions */
+	unsigned short  cfs_enable_1;	/* command set-feature enabled */
+	unsigned short  cfs_enable_2;	/* command set-feature enabled */
+	unsigned short  csf_default;	/* command set-feature default */
+	unsigned short  dma_ultra;	/*  */
+	unsigned short	word89;		/* reserved (word 89) */
+	unsigned short	word90;		/* reserved (word 90) */
+	unsigned short	CurAPMvalues;	/* current APM values */
+	unsigned short	word92;		/* reserved (word 92) */
+	unsigned short	hw_config;	/* hardware config */
+	unsigned short  words94_125[32];/* reserved words 94-125 */
+	unsigned short	last_lun;	/* reserved (word 126) */
+	unsigned short	word127;	/* reserved (word 127) */
+	unsigned short	dlf;		/* device lock function
+					 * 15:9	reserved
+					 * 8	security level 1:max 0:high
+					 * 7:6	reserved
+					 * 5	enhanced erase
+					 * 4	expire
+					 * 3	frozen
+					 * 2	locked
+					 * 1	en/disabled
+					 * 0	capability
+					 */
+	unsigned short  csfo;		/* current set features options
+					 * 15:4	reserved
+					 * 3	auto reassign
+					 * 2	reverting
+					 * 1	read-look-ahead
+					 * 0	write cache
+					 */
+	unsigned short	words130_155[26];/* reserved vendor words 130-155 */
+	unsigned short	word156;
+	unsigned short	words157_159[3];/* reserved vendor words 157-159 */
+	unsigned short	words160_255[95];/* reserved words 160-255 */
+};
+
+/*
+ * IDE "nice" flags. These are used on a per drive basis to determine
+ * when to be nice and give more bandwidth to the other devices which
+ * share the same IDE bus.
+ */
+#define IDE_NICE_DSC_OVERLAP	(0)	/* per the DSC overlap protocol */
+#define IDE_NICE_ATAPI_OVERLAP	(1)	/* not supported yet */
+#define IDE_NICE_0		(2)	/* when sure that it won't affect us */
+#define IDE_NICE_1		(3)	/* when probably won't affect us much */
+#define IDE_NICE_2		(4)	/* when we know it's on our expense */
+
+
+#endif	/* _DARWIN_HDREG_H */

--- a/include/darwin/types.h
+++ b/include/darwin/types.h
@@ -1,0 +1,36 @@
+/*
+ * <darwin/types.h>
+ *
+ * Copyright (c) 2018  Giovanni Merlino <giovanni.merlino@gmail.com>
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ */
+
+#ifndef DARWIN_TYPES_H
+#define DARWIN_TYPES_H
+#include <stdint.h>
+
+typedef u_int8_t        __u8;
+typedef u_int16_t       __u16;
+typedef u_int32_t       __u32;
+typedef u_int64_t       __u64;
+typedef int8_t          __s8;
+typedef int16_t         __s16;
+typedef int32_t         __s32;
+typedef int64_t         __s64;
+
+#endif

--- a/include/libudffs.h
+++ b/include/libudffs.h
@@ -229,7 +229,7 @@ extern size_t decode_string(struct udf_disc *, const dstring *, char *, size_t, 
 extern size_t encode_string(struct udf_disc *, dstring *, const char *, size_t);
 
 /* misc.c */
-extern const char *appname;
+const char *appname;
 size_t gen_uuid_from_vol_set_ident(char[17], const dstring *, size_t);
 
 #endif /* __LIBUDFFS_H */

--- a/mkudffs/main.c
+++ b/mkudffs/main.c
@@ -41,8 +41,12 @@
 #include <limits.h>
 #include <dirent.h>
 #include <sys/ioctl.h>
+#if defined(__linux__)
 #include <linux/fs.h>
 #include <linux/fd.h>
+#elif defined(__APPLE__)
+#include <sys/disk.h>
+#endif
 #include <sys/sysmacros.h>
 
 #include "mkudffs.h"

--- a/mkudffs/main.c
+++ b/mkudffs/main.c
@@ -47,7 +47,9 @@
 #elif defined(__APPLE__)
 #include <sys/disk.h>
 #endif
+#if defined(__linux__)
 #include <sys/sysmacros.h>
+#endif
 
 #include "mkudffs.h"
 #include "defaults.h"

--- a/mkudffs/mkudffs.c
+++ b/mkudffs/mkudffs.c
@@ -38,7 +38,11 @@
 #include <sys/time.h>
 #include <errno.h>
 #include <sys/ioctl.h>
+#if defined(__linux__)
 #include <linux/hdreg.h>
+#elif defined(__APPLE__)
+#include "darwin/hdreg.h"
+#endif
 
 #include "mkudffs.h"
 #include "file.h"

--- a/pktsetup/pktsetup.c
+++ b/pktsetup/pktsetup.c
@@ -27,14 +27,22 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <getopt.h>
+#if defined(__linux__)
 #include <bits/types.h>
+#else
+#include <mach/mach_types.h>
+#include "../include/darwin/types.h"
+#endif
 #include <sys/types.h>
 #include <string.h>
 #include <limits.h>
 #include <stdlib.h>
 #include <errno.h>
-
+#if defined(__linux__)
 #include <linux/cdrom.h>
+#else
+#include "darwin/cdrom.h"
+#endif
 
 /*
  * if we don't have one, we probably have neither

--- a/udfinfo/main.c
+++ b/udfinfo/main.c
@@ -30,7 +30,12 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#if defined(__linux__)
 #include <linux/fs.h>
+#elif defined(__APPLE__)
+#include <sys/disk.h>
+#include "darwin/mount.h"
+#endif
 #include <sys/ioctl.h>
 
 #include "libudffs.h"

--- a/udfinfo/readdisc.c
+++ b/udfinfo/readdisc.c
@@ -28,7 +28,11 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#if defined(__linux__)
 #include <linux/cdrom.h>
+#else
+#include "darwin/cdrom.h"
+#endif
 #include <sys/ioctl.h>
 
 #include "libudffs.h"

--- a/udflabel/main.c
+++ b/udflabel/main.c
@@ -30,7 +30,12 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#if defined(__linux__)
 #include <linux/fs.h>
+#elif defined(__APPLE__)
+#include <sys/disk.h>
+#include "darwin/mount.h"
+#endif
 #include <sys/ioctl.h>
 
 #include "libudffs.h"

--- a/wrudf/ide-pc.c
+++ b/wrudf/ide-pc.c
@@ -27,7 +27,12 @@
 #include <errno.h>
 #include <sys/ioctl.h>
 #include <sys/types.h>		/* for u_char etc. */
+#if defined(__linux__)
 #include <linux/cdrom.h>
+#else
+#include "bswap.h"
+#include "darwin/cdrom.h"
+#endif
 #include <unistd.h>		/* sleep() */
 #include <stdlib.h>
 

--- a/wrudf/wrudf-cdrw.c
+++ b/wrudf/wrudf-cdrw.c
@@ -30,8 +30,11 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
+#if defined(__linux__)
 #include <linux/cdrom.h>		/* for CDROM_DRIVE_STATUS  */
-
+#else
+#include "darwin/cdrom.h"
+#endif
 #include "wrudf.h"
 #include "ide-pc.h"
 #include "bswap.h"


### PR DESCRIPTION
Thanks to your latest advice:

[https://github.com/pali/udftools/issues/13#issuecomment-355498216](https://github.com/pali/udftools/issues/13#issuecomment-355498216)

I've cleaned up the PR: no more CDDL-encumbered code, just enough (otherwise missing) headers, slightly adapted from Linux ones, to let the compiler stop complaining. By the way, with this groundwork out of the way, it is a very straightforward port to FreeBSD, as well.

This is a quite different PR with respect to the fsck work in: [https://github.com/argorain/udftools/pull/1](https://github.com/argorain/udftools/pull/1)

I've tried to keep things as separate (and as simple) as possible, because I think it is valuable to have the macOS port merged even before the fsck is fully upstreamed.

Let me know your opinion.
  