### PR TITLE
Use libdir variable in pktsetup Makefile

### DIFF
--- a/pktsetup/Makefile.am
+++ b/pktsetup/Makefile.am
@@ -3,8 +3,8 @@ pktsetup_SOURCES = pktsetup.c
 EXTRA_DIST = pktsetup.rules
 
 install-data-local:
-	mkdir -p "$(DESTDIR)/lib/udev/rules.d"
-	$(INSTALL_DATA) "$(srcdir)/pktsetup.rules" "$(DESTDIR)/lib/udev/rules.d/80-pktsetup.rules"
+	mkdir -p "$(DESTDIR)$(libdir)/udev/rules.d"
+	$(INSTALL_DATA) "$(srcdir)/pktsetup.rules" "$(DESTDIR)$(libdir)/udev/rules.d/80-pktsetup.rules"
 
 uninstall-local:
-	rm -f "$(DESTDIR)/lib/udev/rules.d/80-pktsetup.rules"
+	rm -f "$(DESTDIR)$(libdir)/udev/rules.d/80-pktsetup.rules"


### PR DESCRIPTION
I use `/usr/lib64` so it would be nice to use $(libdir) instead of using a hardcoded `/lib` value in the Makefile