### PR TITLE
pktsetup/pktsetup.c: do not include <bits/types.h>

### DIFF
--- a/pktsetup/pktsetup.c
+++ b/pktsetup/pktsetup.c
@@ -27,7 +27,6 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <getopt.h>
-#include <bits/types.h>
 #include <sys/types.h>
 #include <string.h>
 #include <limits.h>


### PR DESCRIPTION
This header is not a standard header, and is for example not provided
by the musl C library.

This change has been tested by building udftools against glibc, uClibc
and musl.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>