### PR TITLE
Misc build fixes and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,15 @@ include/config.h
 include/stamp-h1
 */.deps/
 libtool
+.libs
+*.o
+*.lo
+*.la
+.dirstamp
+cdrwtool/cdrwtool
+mkudffs/mkudffs
+pktsetup/pktsetup
+udffsck/udffsck
+udfinfo/udfinfo
+udflabel/udflabel
+wrudf/wrudf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+Makefile.in
+aclocal.m4
+autom4te.cache/
+config/
+configure
+*/Makefile.in
+include/config.in

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,15 @@
+Makefile
 Makefile.in
 aclocal.m4
 autom4te.cache/
 config/
 configure
+config.log
+config.status
 */Makefile.in
+*/Makefile
 include/config.in
+include/config.h
+include/stamp-h1
+*/.deps/
+libtool

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 Makefile
 Makefile.in
 aclocal.m4
+m4/*.m4
 autom4te.cache/
 config/
 configure

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,4 @@
 SUBDIRS = libudffs mkudffs cdrwtool pktsetup udffsck udfinfo udflabel wrudf doc
 dist_doc_DATA = AUTHORS COPYING NEWS README
 EXTRA_DIST = autogen.sh Doxyfile
+ACLOCAL_AMFLAGS = -I m4

--- a/configure.ac
+++ b/configure.ac
@@ -4,6 +4,7 @@ AC_INIT(udftools, 2.0, , , [https://github.com/pali/udftools/])
 AC_CONFIG_AUX_DIR(config)
 AM_CONFIG_HEADER(include/config.h:include/config.in)
 AM_INIT_AUTOMAKE([subdir-objects])
+AC_CONFIG_MACRO_DIRS([m4])
 
 dnl Checks for programs.
 AC_PROG_CC_C99

--- a/configure.ac
+++ b/configure.ac
@@ -14,8 +14,18 @@ if test "$ac_cv_prog_cc_c99" = "no"; then
 	AC_MSG_ERROR([Your C compiler does not support ISO C99.])
 fi
 
-dnl Checks for libraries.
-AC_CHECK_LIB(readline, readline, [ ])
+PKG_PROG_PKG_CONFIG
+
+dnl Checks for libraries, by using pkg-config when available
+if test -n "${PKG_CONFIG}" ; then
+  PKG_CHECK_MODULES([READLINE], [readline], [readline_found=yes], [readline_found=no])
+fi
+
+if test "${readline_found}" != "yes" ; then
+  AC_CHECK_LIB(readline, readline,
+               [AC_SUBST([READLINE_LIBS], [-lreadline])],
+               [])
+fi
 
 dnl Checks for header files.
 AC_HEADER_STDC

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_PREREQ([2.63])
 AC_INIT(udftools, 2.0, , , [https://github.com/pali/udftools/])
 AC_CONFIG_AUX_DIR(config)
 AM_CONFIG_HEADER(include/config.h:include/config.in)
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
 
 dnl Checks for programs.
 AC_PROG_CC_C99

--- a/mkudffs/main.c
+++ b/mkudffs/main.c
@@ -41,6 +41,7 @@
 #include <limits.h>
 #include <dirent.h>
 #include <sys/ioctl.h>
+#include <sys/sysmacros.h>
 #include <linux/fs.h>
 #include <linux/fd.h>
 #include <sys/sysmacros.h>

--- a/wrudf/Makefile.am
+++ b/wrudf/Makefile.am
@@ -5,6 +5,6 @@ wrudf_SOURCES = wrudf.c wrudf-cmnd.c wrudf-desc.c wrudf-cdrw.c wrudf-cdr.c ide-p
 AM_CPPFLAGS = -I$(top_srcdir)/include
 
 if USE_READLINE
-wrudf_LDADD += -lreadline
+wrudf_LDADD += $(READLINE_LIBS)
 AM_CPPFLAGS += -DUSE_READLINE
 endif


### PR DESCRIPTION
Hello,

Here is a patch series doing misc build fixes and improvements:

- Adds the possibility to detect the readline library using pkg-config, which allows to properly handle static linking configurations.
- Fix a number of autoreconf warnings
- Fix a build warning related to the use of major() and minor() macros
- Add a .gitignore file to cleanup the output of "git status"

Thanks!