### PR TITLE
configure.ac: detect readline via pkg-config when possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: c
 matrix:
   include:
     - compiler: gcc-4.4
+      dist: trusty
       env: PLATFORM=x86
       addons:
         apt:
@@ -11,6 +12,7 @@ matrix:
             - libc6-dev:i386
             - gcc-4.4-multilib
     - compiler: gcc-4.4
+      dist: trusty
       env: PLATFORM=x86_64
       addons:
         apt:
@@ -18,6 +20,7 @@ matrix:
             - libreadline-dev
             - gcc-4.4
     - compiler: gcc-4.6
+      dist: trusty
       env: PLATFORM=x86
       addons:
         apt:
@@ -26,6 +29,7 @@ matrix:
             - libc6-dev:i386
             - gcc-4.6-multilib
     - compiler: gcc-4.6
+      dist: trusty
       env: PLATFORM=x86_64
       addons:
         apt:
@@ -66,8 +70,6 @@ matrix:
       env: PLATFORM=x86
       addons:
         apt:
-          sources:
-            - ubuntu-toolchain-r-test
           packages:
             - libreadline-dev:i386
             - libc6-dev:i386
@@ -76,8 +78,6 @@ matrix:
       env: PLATFORM=x86_64
       addons:
         apt:
-          sources:
-            - ubuntu-toolchain-r-test
           packages:
             - libreadline-dev
             - gcc-4.9
@@ -85,8 +85,6 @@ matrix:
       env: PLATFORM=x86
       addons:
         apt:
-          sources:
-            - ubuntu-toolchain-r-test
           packages:
             - libreadline-dev:i386
             - libc6-dev:i386
@@ -95,8 +93,6 @@ matrix:
       env: PLATFORM=x86_64
       addons:
         apt:
-          sources:
-            - ubuntu-toolchain-r-test
           packages:
             - libreadline-dev
             - gcc-5
@@ -120,6 +116,7 @@ matrix:
             - libreadline-dev
             - gcc-6
     - compiler: gcc-7
+      dist: trusty
       env: PLATFORM=x86
       addons:
         apt:
@@ -130,6 +127,7 @@ matrix:
             - libc6-dev:i386
             - gcc-7-multilib
     - compiler: gcc-7
+      dist: trusty
       env: PLATFORM=x86_64
       addons:
         apt:
@@ -158,6 +156,7 @@ matrix:
             - libreadline-dev
             - gcc-8
     - compiler: clang-3.3
+      dist: trusty
       env: PLATFORM=x86
       addons:
         apt:
@@ -167,6 +166,7 @@ matrix:
             - clang-3.3
             - gcc-multilib
     - compiler: clang-3.3
+      dist: trusty
       env: PLATFORM=x86_64
       addons:
         apt:
@@ -174,6 +174,7 @@ matrix:
             - libreadline-dev
             - clang-3.3
     - compiler: clang-3.4
+      dist: trusty
       env: PLATFORM=x86
       addons:
         apt:
@@ -183,6 +184,7 @@ matrix:
             - clang-3.4
             - gcc-multilib
     - compiler: clang-3.4
+      dist: trusty
       env: PLATFORM=x86_64
       addons:
         apt:
@@ -209,8 +211,6 @@ matrix:
       env: PLATFORM=x86
       addons:
         apt:
-          sources:
-            - llvm-toolchain-trusty-3.6
           packages:
             - libreadline-dev:i386
             - libc6-dev:i386
@@ -220,8 +220,6 @@ matrix:
       env: PLATFORM=x86_64
       addons:
         apt:
-          sources:
-            - llvm-toolchain-trusty-3.6
           packages:
             - libreadline-dev
             - clang-3.6
@@ -229,8 +227,6 @@ matrix:
       env: PLATFORM=x86
       addons:
         apt:
-          sources:
-            - llvm-toolchain-trusty-3.7
           packages:
             - libreadline-dev:i386
             - libc6-dev:i386
@@ -240,8 +236,6 @@ matrix:
       env: PLATFORM=x86_64
       addons:
         apt:
-          sources:
-            - llvm-toolchain-trusty-3.7
           packages:
             - libreadline-dev
             - clang-3.7
@@ -281,8 +275,6 @@ matrix:
       env: PLATFORM=x86
       addons:
         apt:
-          sources:
-            - llvm-toolchain-trusty-4.0
           packages:
             - libreadline-dev:i386
             - libc6-dev:i386
@@ -292,8 +284,6 @@ matrix:
       env: PLATFORM=x86_64
       addons:
         apt:
-          sources:
-            - llvm-toolchain-trusty-4.0
           packages:
             - libreadline-dev
             - clang-4.0
@@ -301,8 +291,6 @@ matrix:
       env: PLATFORM=x86
       addons:
         apt:
-          sources:
-            - llvm-toolchain-trusty-5.0
           packages:
             - libreadline-dev:i386
             - libc6-dev:i386
@@ -312,8 +300,6 @@ matrix:
       env: PLATFORM=x86_64
       addons:
         apt:
-          sources:
-            - llvm-toolchain-trusty-5.0
           packages:
             - libreadline-dev
             - clang-5.0
@@ -321,9 +307,6 @@ matrix:
       env: PLATFORM=x86
       addons:
         apt:
-          sources:
-            - llvm-toolchain-trusty-6.0
-            - ubuntu-toolchain-r-test
           packages:
             - libreadline-dev:i386
             - libc6-dev:i386
@@ -333,9 +316,6 @@ matrix:
       env: PLATFORM=x86_64
       addons:
         apt:
-          sources:
-            - llvm-toolchain-trusty-6.0
-            - ubuntu-toolchain-r-test
           packages:
             - libreadline-dev
             - clang-6.0
@@ -343,9 +323,6 @@ matrix:
       env: PLATFORM=x86
       addons:
         apt:
-          sources:
-            - llvm-toolchain-trusty-7
-            - ubuntu-toolchain-r-test
           packages:
             - libreadline-dev:i386
             - libc6-dev:i386
@@ -355,9 +332,6 @@ matrix:
       env: PLATFORM=x86_64
       addons:
         apt:
-          sources:
-            - llvm-toolchain-trusty-7
-            - ubuntu-toolchain-r-test
           packages:
             - libreadline-dev
             - clang-7

--- a/.travis.yml
+++ b/.travis.yml
@@ -323,6 +323,8 @@ matrix:
       env: PLATFORM=x86
       addons:
         apt:
+          sources:
+            - llvm-toolchain-xenial-7
           packages:
             - libreadline-dev:i386
             - libc6-dev:i386
@@ -332,6 +334,8 @@ matrix:
       env: PLATFORM=x86_64
       addons:
         apt:
+          sources:
+            - llvm-toolchain-xenial-7
           packages:
             - libreadline-dev
             - clang-7

--- a/configure.ac
+++ b/configure.ac
@@ -14,18 +14,24 @@ AC_PROG_MKDIR_P
 
 AS_IF([test "$ac_cv_prog_cc_c99" = "no"], [AC_MSG_ERROR([Your C compiler does not support ISO C99.])])
 
-dnl Checks for libraries.
-AC_CHECK_LIB(readline, readline, [ ])
+dnl Checks for libraries, by using pkg-config when available
+PKG_PROG_PKG_CONFIG
+AS_IF([test -n "${PKG_CONFIG}"], [PKG_CHECK_MODULES([READLINE], [readline], [readline_found=yes], [readline_found=no])])
 
-dnl Checks for header files.
-AC_CHECK_HEADERS(readline/readline.h)
+AS_IF([test "${readline_found}" != "yes"],
+  [AC_CHECK_LIB(readline, readline,
+               [AC_CHECK_HEADERS(readline/readline.h,
+		                 [AC_SUBST([READLINE_LIBS], [-lreadline])
+				 readline_found=yes],
+				 [readline_found=no])],
+               [readline_found=no])
+  ])
 
 dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_INLINE
 AC_C_BIGENDIAN
 AC_SYS_LARGEFILE
 
-PKG_PROG_PKG_CONFIG
 PKG_CHECK_MODULES(UDEV, [udev], [ac_cv_udevdir=`$PKG_CONFIG --variable=udevdir udev`], [ac_cv_udevdir=""])
 AM_CONDITIONAL(UDEVDIR, [test "$ac_cv_udevdir" != ""])
 AC_SUBST(UDEVDIR, $ac_cv_udevdir)
@@ -33,7 +39,7 @@ AC_SUBST(UDEVDIR, $ac_cv_udevdir)
 dnl Checks for library functions.
 AC_SUBST(LTLIBOBJS)
 
-AM_CONDITIONAL(USE_READLINE, test "$ac_cv_lib_readline_readline" = "yes" -a "$ac_cv_header_readline_readline_h" = "yes")
+AM_CONDITIONAL(USE_READLINE, test "$readline_found" = "yes")
 
 AC_CONFIG_FILES(Makefile libudffs/Makefile mkudffs/Makefile cdrwtool/Makefile pktsetup/Makefile udffsck/Makefile udfinfo/Makefile udflabel/Makefile wrudf/Makefile doc/Makefile)
 

--- a/wrudf/Makefile.am
+++ b/wrudf/Makefile.am
@@ -5,6 +5,6 @@ wrudf_SOURCES = wrudf.c wrudf-cmnd.c wrudf-desc.c wrudf-cdrw.c wrudf-cdr.c ide-p
 AM_CPPFLAGS = -I$(top_srcdir)/include
 
 if USE_READLINE
-wrudf_LDADD += -lreadline
+wrudf_LDADD += $(READLINE_LIBS)
 AM_CPPFLAGS += -DUSE_READLINE
 endif


### PR DESCRIPTION
pkg-config automatically handles static linking situations, where for
example readline is linked against ncurses, and therefore -lncurses
needs to be passed in addition to -lreadline.

This proposal uses pkg-config when available. If pkg-config is not
found, or readline is not found via pkg-config, we fallback to the
existing AC_CHECK_LIB(). This AC_CHECK_LIB() test is modified to set
READLINE_LIBS, like PKG_CHECK_MODULES() does. The Makefile.am
consequently uses READLINE_LIBS instead of hardcoding -lreadline.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
[Retrieved (and slightly updated) from:
https://git.buildroot.net/buildroot/tree/package/udftools/0002-configure.ac-detect-readline-via-pkg-config-when-pos.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>