### PR TITLE
configure.ac: detect readline via pkg-config when possible

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,18 +14,24 @@ AC_PROG_MKDIR_P
 
 AS_IF([test "$ac_cv_prog_cc_c99" = "no"], [AC_MSG_ERROR([Your C compiler does not support ISO C99.])])
 
-dnl Checks for libraries.
-AC_CHECK_LIB(readline, readline, [ ])
+dnl Checks for libraries, by using pkg-config when available
+PKG_PROG_PKG_CONFIG
+AS_IF([test -n "${PKG_CONFIG}"], [PKG_CHECK_MODULES([READLINE], [readline], [readline_found=yes], [readline_found=no])])
 
-dnl Checks for header files.
-AC_CHECK_HEADERS(readline/readline.h)
+AS_IF([test "${readline_found}" != "yes"],
+  [AC_CHECK_LIB(readline, readline,
+               [AC_CHECK_HEADERS(readline/readline.h,
+		                 [AC_SUBST([READLINE_LIBS], [-lreadline])
+				 readline_found=yes],
+				 [readline_found=no])],
+               [readline_found=no])
+  ])
 
 dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_INLINE
 AC_C_BIGENDIAN
 AC_SYS_LARGEFILE
 
-PKG_PROG_PKG_CONFIG
 PKG_CHECK_MODULES(UDEV, [udev], [ac_cv_udevdir=`$PKG_CONFIG --variable=udevdir udev`], [ac_cv_udevdir=""])
 AM_CONDITIONAL(UDEVDIR, [test "$ac_cv_udevdir" != ""])
 AC_SUBST(UDEVDIR, $ac_cv_udevdir)
@@ -33,7 +39,7 @@ AC_SUBST(UDEVDIR, $ac_cv_udevdir)
 dnl Checks for library functions.
 AC_SUBST(LTLIBOBJS)
 
-AM_CONDITIONAL(USE_READLINE, test "$ac_cv_lib_readline_readline" = "yes" -a "$ac_cv_header_readline_readline_h" = "yes")
+AM_CONDITIONAL(USE_READLINE, test "$readline_found" = "yes")
 
 AC_CONFIG_FILES(Makefile libudffs/Makefile mkudffs/Makefile cdrwtool/Makefile pktsetup/Makefile udffsck/Makefile udfinfo/Makefile udflabel/Makefile wrudf/Makefile doc/Makefile)
 

--- a/wrudf/Makefile.am
+++ b/wrudf/Makefile.am
@@ -5,6 +5,6 @@ wrudf_SOURCES = wrudf.c wrudf-cmnd.c wrudf-desc.c wrudf-cdrw.c wrudf-cdr.c ide-p
 AM_CPPFLAGS = -I$(top_srcdir)/include
 
 if USE_READLINE
-wrudf_LDADD += -lreadline
+wrudf_LDADD += $(READLINE_LIBS)
 AM_CPPFLAGS += -DUSE_READLINE
 endif


### PR DESCRIPTION
pkg-config automatically handles static linking situations, where for
example readline is linked against ncurses, and therefore -lncurses
needs to be passed in addition to -lreadline.

This proposal uses pkg-config when available. If pkg-config is not
found, or readline is not found via pkg-config, we fallback to the
existing AC_CHECK_LIB(). This AC_CHECK_LIB() test is modified to set
READLINE_LIBS, like PKG_CHECK_MODULES() does. The Makefile.am
consequently uses READLINE_LIBS instead of hardcoding -lreadline.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
[Retrieved (and slightly updated) from:
https://git.buildroot.net/buildroot/tree/package/udftools/0002-configure.ac-detect-readline-via-pkg-config-when-pos.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>